### PR TITLE
fix broken link

### DIFF
--- a/text-editors/README.md
+++ b/text-editors/README.md
@@ -12,7 +12,7 @@
 + [Typora](https://www.typora.io/) for Markdown
 
 ## Web applications
-+ [Draft](https://draftin.com/draft/users/sign_up) for Markdown
++ [Draft](https://draftin.com/) for Markdown
 + [iA Writer](https://ia.net/writer) for Markdown
 
 


### PR DESCRIPTION
link to `https://draftin.com/draft/users/sign_up` is broken: 

<img width="544" alt="Screenshot 2022-12-09 at 20 42 31" src="https://user-images.githubusercontent.com/49357401/206819507-0c6f1219-3fdf-4381-b7e6-2b0d111f344f.png">

fixed with `https://draftin.com/`