### PR TITLE
Add VS Code to list, and mention Atom repo archival

### DIFF
--- a/text-editors/README.md
+++ b/text-editors/README.md
@@ -4,7 +4,7 @@
 + [Sublime Text](https://www.sublimetext.com/)
 + [Notepad++](https://notepad-plus-plus.org/)
 + [TextMate](https://macromates.com/)
-+ [Atom](https://atom.io/) (Repository will be archived on December 15, 2022)
++ [Atom](https://atom.io/) (The source repository is archived on GitHub)
 + [Visual Studio Code](https://code.visualstudio.com/)
 
 ## Paid desktop applications

--- a/text-editors/README.md
+++ b/text-editors/README.md
@@ -4,7 +4,8 @@
 + [Sublime Text](https://www.sublimetext.com/)
 + [Notepad++](https://notepad-plus-plus.org/)
 + [TextMate](https://macromates.com/)
-+ [Atom](https://atom.io/)
++ [Atom](https://atom.io/) (Repository will be archived on December 15, 2022)
++ [Visual Studio Code](https://code.visualstudio.com/)
 
 ## Paid desktop applications
 + [Coda 2](https://panic.com/coda/)


### PR DESCRIPTION
## Changes:

- Add VS Code to list
- Mention Atom repository archival

## Context:

### Atom repo archival

The Atom repository is going to be archived soon: [^atom-repo]

> Atom and all repositories under Atom will be archived on December 15, 2022. Learn more in our [official announcement](https://github.blog/2022-06-08-sunsetting-atom/)

I use VS Code a lot to work on documentation, so maybe it should go on the list as well?

[^atom-repo]: [Link to `atom/atom` repository](https://github.com/atom/atom)