### PR TITLE
Add Plain Language style guide

### DIFF
--- a/style/README.md
+++ b/style/README.md
@@ -6,6 +6,7 @@ It is essential to use a style guide and content strategy when you create any te
 + [Microsoft writing style guide](https://docs.microsoft.com/en-us/style-guide/welcome/)
 + [Atlassian writing style](https://atlassian.design/guidelines/brand/writing-style-1)
 + [GOV.UK content design](https://www.gov.uk/guidance/content-design)
++ [Plain Language style guide](https://www.plainlanguage.gov/)
 + [The Economist style guide](https://cdn.static-economist.com/sites/default/files/store/Style_Guide_2015.pdf)
 + Google guides
    + [Material design writing](https://material.io/design/communication/writing.html?fbclid=IwAR18sxVvU9Yoq87kgnUCz8yJLxjNTH4KFcnur_QvyBFUcSJK5OhcURIfTl4)


### PR DESCRIPTION
## Changes:

- Add the Plain Language style guide [^link]

## Context:

I like this style guide, so that's why I want to put it in the list. I'm not sure what's the best link name, the site mentions:

> You may use any of the content on this site without explicit permission. As a federal website, the content is in the public domain. We ask only that you credit our work by citing back to PLAIN and www.plainlanguage.gov.

So maybe I should use one of these link styles?

- [Plain Language style guide, PLAIN](#)
- [plainlanguage.gov style guide, PLAIN](#)

[^link]: https://www.plainlanguage.gov/